### PR TITLE
fix: add prefix v when installing from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ $(BUF):
 	@mkdir -p $(CACHE_BIN)
 ifeq ($(BUF_INSTALL_FROM_SOURCE),true)
 	$(eval BUF_TMP := $(shell mktemp -d))
-	cd $(BUF_TMP); go get github.com/bufbuild/buf/cmd/buf@$(BUF_VERSION)
+	cd $(BUF_TMP); go get github.com/bufbuild/buf/cmd/buf@v$(BUF_VERSION)
 	@rm -rf $(BUF_TMP)
 else
 	curl -sSL \


### PR DESCRIPTION
Ran into a minor typo when installing from source, the version tag was not prefixed with `v`. 
