### PR TITLE
Update all Bufstream examples in buf-examples for 0.4.0

### DIFF
--- a/bufstream/docker-compose/bufstream.yaml
+++ b/bufstream/docker-compose/bufstream.yaml
@@ -13,17 +13,3 @@ data:
 metadata:
   postgres:
     string: postgresql://root:password@localhost:5432/bufstream
-
-metrics:
-  otlp:
-    # Required: Type of transport to use for OTLP. Must be "http" or "grpc".
-    type: http
-    # Required: URL of OTLP endpoint to export metrics to.
-    url: https://localhost:4318
-debug:
-  # Address to listen for connections for debug information. If configured,
-  # pprof and Prometheus exported metrics will be exposed on this address.
-  listen_address: localhost:12345
-logging:
-  # Log level, defaults to info.
-  level: debu

--- a/bufstream/docker-compose/docker-compose.yml
+++ b/bufstream/docker-compose/docker-compose.yml
@@ -35,7 +35,7 @@ services:
 
   # The Bufstream broker, available at localhost:9092.
   bufstream:
-    image: bufbuild/bufstream
+    image: bufbuild/bufstream:0.4.0
     depends_on:
       postgres: { "condition": "service_healthy" }
       mc: { "condition": "service_completed_successfully" }

--- a/bufstream/iceberg-quickstart/config/bufstream.yaml
+++ b/bufstream/iceberg-quickstart/config/bufstream.yaml
@@ -1,3 +1,4 @@
+version: v1beta1
 schema_registry:
   confluent:
     url: "https://demo.buf.dev/integrations/confluent/bufstream-demo"
@@ -11,7 +12,7 @@ data:
       string: admin
     secret_access_key:
       string: password
-# iceberg:
-#   - name: local-rest-catalog
-#     rest:
-#       url: http://iceberg-rest:8181
+iceberg:
+  - name: local-rest-catalog
+    rest:
+      url: http://iceberg-rest:8181

--- a/bufstream/iceberg-quickstart/docker-compose.yml
+++ b/bufstream/iceberg-quickstart/docker-compose.yml
@@ -77,7 +77,7 @@ services:
   # Iceberg catalog for archival. Additional configuration is in
   # config/bufstream.yaml.
   bufstream:
-    image: bufbuild/bufstream:0.3.44
+    image: bufbuild/bufstream:0.4.0
     hostname: localhost
     container_name: bufstream
     networks:

--- a/protovalidate/bufstream/finish/config/bufstream.yaml
+++ b/protovalidate/bufstream/finish/config/bufstream.yaml
@@ -1,24 +1,6 @@
 # yaml-language-server: $schema=schema/buf.bufstream.config.v1alpha1.BufstreamConfig.schema.json
-cluster: demo
-zone: localhost
-in_memory: true
-kafka:
-  address:
-    host: 0.0.0.0
-    port: 9092
-  public_address:
-    host: 0.0.0.0
-    port: 9092
-data_enforcement:
-  schema_registries:
-    - name: csr
-      confluent:
-        url: "https://demo.buf.dev/integrations/confluent/bufstream-demo"
-        instance_name: "bufstream-demo"
-  produce:
-    - topics: { all: true }
-      schema_registry: csr
-      values:
-        on_parse_error: REJECT_BATCH
-        validation:
-          on_error: REJECT_BATCH
+version: v1beta1
+schema_registry:
+  confluent:
+    url: "https://demo.buf.dev/integrations/confluent/bufstream-demo"
+    instance_name: "bufstream-demo"

--- a/protovalidate/bufstream/start/config/bufstream.yaml
+++ b/protovalidate/bufstream/start/config/bufstream.yaml
@@ -1,22 +1,6 @@
 # yaml-language-server: $schema=schema/buf.bufstream.config.v1alpha1.BufstreamConfig.schema.json
-cluster: demo
-zone: localhost
-in_memory: true
-kafka:
-  address:
-    host: 0.0.0.0
-    port: 9092
-  public_address:
-    host: 0.0.0.0
-    port: 9092
-data_enforcement:
-  schema_registries:
-    - name: csr
-      confluent:
-        url: "https://demo.buf.dev/integrations/confluent/bufstream-demo"
-        instance_name: "bufstream-demo"
-  produce:
-    - topics: { all: true }
-      schema_registry: csr
-      values:
-        on_parse_error: REJECT_BATCH
+version: v1beta1
+schema_registry:
+  confluent:
+    url: "https://demo.buf.dev/integrations/confluent/bufstream-demo"
+    instance_name: "bufstream-demo"


### PR DESCRIPTION
If this repository is cloned and you switch to this branch, you should be able to follow the documentation in the previews for the identically-named docs and Protovalidate PRs to:

1. Complete the Iceberg quickstart
2. Complete Protovalidate's Bufstream and Kafka guide (under "Integrations" in the nav)
3. Stand up the Compose example (navigate to `bufstream/docker-compose` and run `docker compose up`)